### PR TITLE
fix: nvm install link

### DIFF
--- a/src/deploy/index.md
+++ b/src/deploy/index.md
@@ -86,7 +86,7 @@ nvm 可以用于管理 Node.js。
 打开终端，使用一键脚本，可以便捷地安装 nvm：
 
 ```bash
-bash -c "$(curl -fsSL https://gitee.com/RubyKids/nvm-cn/raw/master/install.sh)"
+bash -c "$(curl -fsSL https://gitee.com/RubyKids/nvm-cn/raw/main/install.sh)"
 ```
 
 重启终端即可生效


### PR DESCRIPTION
预设的安装nvm的步骤中，原来的一键安装脚本的url发生了变更，文档中的链接访问时为404
找到对应的gitee网站变更为了新的链接
见https://gitee.com/RubyKids/nvm-cn