### PR TITLE
refactor(search): use official search feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@types/markdown-it": "*",
     "@types/prismjs": "*",
-    "flexsearch": "^0.7.31",
     "@vue/theme": "2.2.1",
     "@vueuse/core": "10.0.2",
     "@vueuse/head": "1.1.23",
@@ -33,7 +32,6 @@
     "prismjs": "^1.29.0",
     "segment": "^0.1.3",
     "shiki": "0.14.1",
-    "vitepress-plugin-search": "1.0.4-alpha.20",
     "vite": "4.2.1",
     "vitepress": "1.0.0-alpha.69",
     "vue": "3.2.47"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ dependencies:
   '@vueuse/head':
     specifier: 1.1.23
     version: 1.1.23(vue@3.2.47)
-  flexsearch:
-    specifier: ^0.7.31
-    version: 0.7.31
   markdown-it:
     specifier: ^13.0.1
     version: 13.0.1
@@ -40,9 +37,6 @@ dependencies:
   vitepress:
     specifier: 1.0.0-alpha.69
     version: 1.0.0-alpha.69(@types/node@18.15.11)(terser@5.16.9)
-  vitepress-plugin-search:
-    specifier: 1.0.4-alpha.20
-    version: 1.0.4-alpha.20(flexsearch@0.7.31)(vitepress@1.0.0-alpha.69)(vue@3.2.47)
   vue:
     specifier: 3.2.47
     version: 3.2.47
@@ -481,10 +475,6 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
     dev: true
-
-  /@types/flexsearch@0.7.3:
-    resolution: {integrity: sha512-HXwADeHEP4exXkCIwy2n1+i0f1ilP1ETQOH5KDOugjkTFZPntWo0Gr8stZOaebkxsdx+k0X/K6obU/+it07ocg==}
-    dev: false
 
   /@types/linkify-it@3.0.2:
     resolution: {integrity: sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==}
@@ -1017,10 +1007,6 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
-  /flexsearch@0.7.31:
-    resolution: {integrity: sha512-XGozTsMPYkm+6b5QL3Z9wQcJjNYxp0CYn3U1gO7dwD6PAqU1SVWZxI9CCg3z+ml3YfqdPnrBehaBrnH2AGKbNA==}
-    dev: false
-
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1042,10 +1028,6 @@ packages:
     dependencies:
       is-glob: 4.0.3
     dev: true
-
-  /glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-    dev: false
 
   /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -1623,23 +1605,6 @@ packages:
       terser: 5.16.9
     optionalDependencies:
       fsevents: 2.3.2
-
-  /vitepress-plugin-search@1.0.4-alpha.20(flexsearch@0.7.31)(vitepress@1.0.0-alpha.69)(vue@3.2.47):
-    resolution: {integrity: sha512-zG+ev9pw1Mg7htABlFCNXb8XwnKN+qfTKw+vU0Ers6RIrABx+45EAAFBoaL1mEpl1FRFn1o/dQ7F4b8GP6HdGQ==}
-    engines: {node: ^14.13.1 || ^16.7.0 || >=18}
-    peerDependencies:
-      flexsearch: ^0.7.31
-      vitepress: ^1.0.0-alpha.65
-      vue: '3'
-    dependencies:
-      '@types/flexsearch': 0.7.3
-      '@types/markdown-it': 12.2.3
-      flexsearch: 0.7.31
-      glob-to-regexp: 0.4.1
-      markdown-it: 13.0.1
-      vitepress: 1.0.0-alpha.69(@types/node@18.15.11)(terser@5.16.9)
-      vue: 3.2.47
-    dev: false
 
   /vitepress@1.0.0-alpha.69(@types/node@18.15.11)(terser@5.16.9):
     resolution: {integrity: sha512-d7Vz+S/1i/7szVUSOHJf12APtoGlHXIJXzDvXLChhlE000TVzWoYX6rUAchjJzfxdFjng3Eo96ZkPs7OJxDjMg==}

--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -3,10 +3,7 @@
 import { join, resolve } from 'path'
 import Windicss from 'vite-plugin-windicss'
 import { UserConfig } from 'vitepress'
-import { SearchPlugin } from "vitepress-plugin-search";
-import flexSearchIndexOptions from "flexsearch";
 import navBar, {
-  deployBar,
   deploySideBar,
   devBar,
   experimentBar,
@@ -85,6 +82,9 @@ const config: UserConfig = {
   scrollOffset: 'header',
 
   themeConfig: {
+    search: {
+      provider: "local"
+    },
     logo: '/logo.png',
     editLink: {
       // repo: 'mx-space/docs',
@@ -137,12 +137,6 @@ const config: UserConfig = {
     },
     plugins: [
       // NavbarFix(),
-      SearchPlugin({
-        ...flexSearchIndexOptions,
-        tokenize: 'full',
-        buttonLabel: '搜索',
-        placeholder: '搜索文档',
-      }),
       Windicss({
         config: join(__dirname, '../../windi.config.ts'),
       }),


### PR DESCRIPTION
### Description

使用 Vitepress 的内置本地搜索功能

### Additional context

<img width="1727" alt="CleanShot 2023-04-16 at 10 31 06@2x" src="https://user-images.githubusercontent.com/62133302/232262968-10f7d648-1b65-4b6b-a6d1-1b3808260c24.png">

另外，似乎在 `dev` 的时候这个搜索功能是无效的？只有在构建后使用 `serve` 才可以看到效果